### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Django Feed Me
 > Looking For Authors!  This project is currently looking for a user to take it over.  If that sounds like you, send a note to derek at stegelman dot com or open up an issue in this repository.
 
 [![Build Status](https://travis-ci.org/dstegelman/django-feedme.png?branch=master)](https://travis-ci.org/dstegelman/django-feedme)
-[![Pypi Version](https://pypip.in/v/django-feedme/badge.png)](https://crate.io/packages/django-feedme/)
+[![Pypi Version](https://img.shields.io/pypi/v/django-feedme.svg)](https://crate.io/packages/django-feedme/)
 
 
 Django Feed Me is a replacement for Google Reader.  It keeps track of your feeds, fetches the RSS feeds


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-feedme))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-feedme`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.